### PR TITLE
Fixed event handling so search occurs on return

### DIFF
--- a/src/views/pages/information-pages/Index.vue
+++ b/src/views/pages/information-pages/Index.vue
@@ -22,7 +22,9 @@
                 />
               </gov-grid-column>
               <gov-grid-column width="one-quarter">
-                <gov-button @click="clearSearch">Cancel</gov-button>
+                <gov-button type="button" @click="clearSearch"
+                  >Cancel</gov-button
+                >
               </gov-grid-column>
             </gov-grid-row>
           </gov-form-group>
@@ -109,7 +111,6 @@ export default {
   methods: {
     async fetchInformationPages() {
       this.loading = true;
-
       const { data } = await http.get("/information-pages/index", {
         params: this.params
       });


### PR DESCRIPTION
### Summary
https://app.shortcut.com/helpyourselfsutton/story/1481/hitting-they-return-key-doesn-t-perform-a-search

Fixed mishandling of events so return key calls search method

### Development checklist
- [x] The code has been linted `npm run lint --fix`

### Release checklist
NA

### Notes
NA
