### PR TITLE
Bugfix/page collection resources

### DIFF
--- a/src/views/pages/forms/PageForm.vue
+++ b/src/views/pages/forms/PageForm.vue
@@ -162,7 +162,11 @@ export default {
     },
     pageCollectionIds() {
       return this.page
-        ? this.page.collections.map(collection => collection.id)
+        ? this.page.collection_categories
+            .map(collection => collection.id)
+            .concat(
+              this.page.collection_personas.map(collection => collection.id)
+            )
         : [];
     }
   },


### PR DESCRIPTION
### Summary
https://app.shortcut.com/helpyourselfsutton/story/1495/allow-collections-to-be-assigned-to-landing-pages
The pages api had changed the way associated collections were presented. Changed the method of collecting the IDs of associated collections.

### Development checklist
- [x] The code has been linted `npm run lint --fix`

### Release checklist
NA

### Notes
NA
